### PR TITLE
Reorder columns in PaperTable header

### DIFF
--- a/app/_components/PaperTable.tsx
+++ b/app/_components/PaperTable.tsx
@@ -47,10 +47,10 @@ export function PaperTable({ papers, onPaperClick }: PaperTableProps) {
                     <TableHeader>
                         <TableRow className="bg-muted/50">
                             <TableHead className="font-semibold">
-                                Title
-                            </TableHead>
-                            <TableHead className="font-semibold">
                                 Subject Code
+                            </TableHead>
+                             <TableHead className="font-semibold">
+                                Title
                             </TableHead>
                             <TableHead className="font-semibold">
                                 Department


### PR DESCRIPTION
Moved the 'Title' column after 'Subject Code' in the PaperTable header to adjust the display order.