### PR TITLE
Fix: Correct Project Structure formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,18 +99,25 @@ To contribute past papers, please create an Issue or submit a Pull Request. Sinc
 
 ## 📁 Project Structure
 
-\\\
+```
 past-paper-portal/
-├── app/
-│   ├── api/               # Next.js Serverless/Edge API Routes
-│   ├── _components/       # Reusable modular React UI components
-│   ├── gpa-calculator/    # Dedicated GPA Calculator pages
-│   └── page.tsx           # Home Portal view
-├── components/ui/         # Shadcn/UI primitive components
-├── lib/                   # Database interfaces and API logic (ratelimits)
-├── scripts/               # Python ETL scripts for seed formatting
-└── database-setup.sql     # PostgreSQL core tables setup 
-\\\
+├── app/                          # Next.js App Router directory
+│   ├── api/                      # Next.js Serverless/Edge API Routes
+│   ├── _components/              # Reusable modular React UI components
+│   ├── gpa-calculator/           # Dedicated GPA Calculator pages
+│   └── page.tsx                  # Home Portal view
+├── components/
+│   └── ui/                       # Shadcn/UI primitive components
+├── lib/                          # Database interfaces and API logic (ratelimits)
+├── public/                       # Static assets
+├── scripts/                      # Python ETL scripts for seed formatting
+├── database-setup.sql            # PostgreSQL core tables setup
+├── next.config.ts                # Next.js configuration
+├── tsconfig.json                 # TypeScript configuration
+├── postcss.config.mjs            # PostCSS configuration
+├── eslint.config.mjs             # ESLint configuration
+└── package.json                  # Project dependencies
+```
 
 ---
 


### PR DESCRIPTION
## Description
Fixed the Project Structure section in README.md which was displaying incorrectly due to improper code fence syntax.

## Changes
- Replaced invalid `\\\` code fence markers with proper markdown ``` ``` syntax
- Improved structure clarity by properly indenting nested directories
- Added missing directories (`public/`, config files, `package.json`) to the tree
- Aligned inline comments for better readability

## Before & After
<img width="855" height="277" alt="Screenshot 2026-04-15 082523" src="https://github.com/user-attachments/assets/67f955ad-9cce-4e11-9eab-ae076ecd52f3" />

<img width="883" height="499" alt="Screenshot 2026-04-15 082440" src="https://github.com/user-attachments/assets/5d0c55f1-1e0c-4bac-8598-94304e3c6153" />


## Type of Change
- [x] Documentation update
- [ ] Code change
- [ ] Bug fix
- [ ] New feature

## Checklist
- [x] My changes follow the project style guidelines
- [x] I have updated the documentation accordingly
- [x] No new warnings have been generated