### PR TITLE
Update timetable: correct exam dates/times

### DIFF
--- a/lib/timetable.ts
+++ b/lib/timetable.ts
@@ -74,7 +74,7 @@ Date,Time,Dept.,Subject,Title
 29.04.2026,9.00 a.m. - 12.00 p.m.,EET,EET 2301,Digital & Analog Electronics
 13.05.2026,2.00 p.m. - 4.00 p.m.,BPT,BPT 2205,Molecular Biology (Theory)
 15.05.2026,2.00 p.m. - 4.00 p.m.,ICT,ICT 2304,Object Oriented Programming
-01.06.2026,9.00 a.m. - 12.00 p.m.,ICT,ICT 2304,Object Oriented Programming (Practical)
+01.06.2026,9.00 a.m. - 11.00 a.m.,ICT,ICT 2304,Object Oriented Programming (Practical)
 05.05.2026,1.00 p.m. - 4.00 p.m.,ALL,CMT 2301,Fundamental of Statistics for Technology
 07.05.2026,9.00 a.m. - 12.00 p.m.,ALL,CMT 2202,Communication Skills III (English) (Theory)
 11.05.2026,9.00 a.m. - 11.00 a.m.,FDT,FDT 2202,Basic Biochemistry
@@ -83,7 +83,7 @@ Date,Time,Dept.,Subject,Title
 13.05.2026,2.00 p.m. - 4.00 p.m.,ICT,ICT 2207,Software System Design
 13.05.2026,2.00 p.m. - 4.00 p.m.,EET,EET 2208,Introduction to Electrical Power
 15.05.2026,2.00 p.m. - 4.00 p.m.,BPT,BPT 2203,Genetics and Evolution
-14.05.2026,2.00 p.m. - 4.00 p.m.,FDT,FDT 2201,Physical Chemistry
+15.05.2026,2.00 p.m. - 4.00 p.m.,FDT,FDT 2201,Physical Chemistry
 18.05.2026,2.00 p.m. - 4.00 p.m.,ICT,ICT 2202,Operating Systems
 18.05.2026,2.00 p.m. - 4.00 p.m.,MTT,MTT 2202,Chemistry for Materials Technology
 18.05.2026,2.00 p.m. - 4.00 p.m.,BPT,BPT 2202,Introduction to Bioprocess Technology (Theory)
@@ -101,7 +101,7 @@ Date,Time,Dept.,Subject,Title
 14.05.2026,9.00 a.m. - 11.00 a.m.,BPT,BPT 3208,Industrial Microbiology - Theory
 18.05.2026,9.00 a.m. - 12.00 p.m.,EET,EET 3301,Electrical Power Systems
 18.05.2026,9.00 a.m. - 12.00 p.m.,MTT,MTT 3307,Metallurgy I
-14.04.2026,9.00 a.m. - 12.00 p.m.,ICT,ICT 3312,Software Verification and Validation
+05.05.2026,9.00 a.m. - 12.00 p.m.,ICT,ICT 3312,Software Verification and Validation
 28.04.2026,9.00 a.m. - 11.00 a.m.,ICT,ICT 3203,Scientific Computer Applications (Th & Pr)
 27.04.2026,2.00 p.m. - 4.00 p.m.,BPT,BPT 3203,Bioprocess Instrumentation and Control
 28.04.2026,9.00 a.m. - 11.00 p.m.,FDT,FDT 3203,Food Analysis
@@ -111,12 +111,12 @@ Date,Time,Dept.,Subject,Title
 30.04.2026,2.00 p.m. - 4.00 p.m.,BPT,BPT 3304,Molecular Modelling (Theory)
 30.04.2026,2.00 p.m. - 4.00 p.m.,EET,EET 3203,Computer Systems
 30.04.2026,2.00 p.m. - 4.00 p.m.,MTT,MTT 3204,Workshop Technology II
-30.04.2026,2.00 p.m. - 4.00 p.m.,ICT,ICT 3307,Computational Statistics (Theory)
+14.05.2026,9.00 a.m. - 11.00 a.m.,ICT,ICT 3307,Computational Statistics (Theory)
 05.05.2026,9.00 a.m. - 11.00 a.m.,BPT,BPT 3205,Bioprocess Optimization and Simulation
 05.05.2026,9.00 a.m. - 11.00 a.m.,FDT,FDT 3205,Functional Food and Food Toxicology
 05.05.2026,9.00 a.m. - 11.00 a.m.,EET,EET 3206,Automation Technology I
 05.05.2026,9.00 a.m. - 11.00 a.m.,MTT,MTT 3212,Non Destructive Testing of Materials
-05.05.2026,9.00 a.m. - 11.00 a.m.,ICT,ICT 3208,Design and Analysis of Algorithm
+11.05.2026,2.00 p.m. - 4.00 p.m.,ICT,ICT 3208,Design and Analysis of Algorithm
 07.05.2026,2.00 p.m. - 5.00 p.m.,ICT,ICT 3315,Internet of Things
 07.05.2026,2.00 p.m. - 4.00 p.m.,BPT,BPT 3207,Enzyme Technology
 07.05.2026,2.00 p.m. - 4.00 p.m.,FDT,FDT 3207,Confectionary and Beverage Technology
@@ -125,20 +125,20 @@ Date,Time,Dept.,Subject,Title
 11.05.2026,2.00 p.m. - 4.00 p.m.,BPT,BPT 3206,Molecular Immunology and Current Application
 11.05.2026,2.00 p.m. - 4.00 p.m.,EET,EET 3202,Communication Systems
 11.05.2026,2.00 p.m. - 5.00 p.m.,MTT,MTT 3306,Ceramic Technology II
-11.05.2026,2.00 p.m. - 4.00 p.m.,ICT,ICT 3218,Basics of Virtual Reality
+30.04.2026,2.00 p.m. - 4.00 p.m.,ICT,ICT 3218,Basics of Virtual Reality
 14.05.2026,9.00 a.m. - 11.00 a.m.,FDT,FDT 3201,Fruits & Vegetables Processing Technology
 14.05.2026,9.00 a.m. - 12.00 p.m.,EET,EET 3305,Control Systems
 26.05.2026,9.00 a.m. onwards,ICT,ICT 3307,Computational Statistics (Practical)
 26.05.2026,9.00 a.m. onwards,BPT,BPT 3208,Industrial Microbiology (Practical)
 
-20.05.2026,2.00 p.m. - 4.00 p.m.,EET,EET 3210,Electrical Installations
+26.05.2026,9.00 a.m. - 11.00 a.m.,EET,EET 3210,Electrical Installations
 02.06.2026,9.00 a.m. onwards,BPT,BPT 3304,Molecular Modelling (Practical)
 18.05.2026,9.00 a.m. - 11.00 a.m.,FDT,FDT 3202,Food Engineering
 20.05.2026,2.00 p.m. -4.00 p.m.,MTT,MTT 3202,Degradation of Materials
 19.05.2026,9.00 a.m. - 11.00 a.m.,BPT,BPT 3209,Scientific Writing (20-21 Batch)
-20.05.2026,2.00 p.m. - 4.00 p.m.,BPT,BPT 3302,Bioinformatics (Theory)
+20.05.2026,2.00 p.m. - 5.00 p.m.,BPT,BPT 3302,Bioinformatics (Theory)
 20.05.2026,2.00 p.m. - 4.00 p.m.,ICT,ICT 3217,Advance Computer Networks
-22.05.2026,2.00 p.m. - 4.00 p.m.,ALL,CML 3101,Legal and Patent Aspects
+22.05.2026,2.00 p.m. - 3.00 p.m.,ALL,CML 3101,Legal and Patent Aspects
 18.05.2026,9.00 a.m. - 11.00 a.m.,BPT,BPT 3201,Molecular Microbiology
 18.05.2026,9.00 a.m. - 11.00 a.m.,ICT,ICT 3201,Software Project Management
 29.05.2026,9.00 a.m. onwards,BPT,BPT 3302,Bioinformatics (Practical)
@@ -148,17 +148,17 @@ Date,Time,Dept.,Subject,Title
 Date,Time,Dept.,Subject,Title
 21.05.2026,2.00 p.m. - 4.00 p.m.,FDT,FDT 4203,Water Science & Technology
 21.05.2026,2.00 p.m. - 5.00 p.m.,BPT,BPT 4301,Drug Designing (Theory)
-21.05.2026,2.00 p.m. - 5.00 p.m.,EET,EET 4304,Power Electronics
+04.05.2026,2.00 p.m. - 5.00 p.m.,EET,EET 4304,Power Electronics
 21.05.2026,2.00 p.m. - 5.00 p.m.,MTT,MTT 4303,Ceramic Technology III
 06.05.2026,1.00 p.m. - 3.00 p.m.,BPT,BPT 4205,Plant Cell Culture
 06.05.2026,1.00 p.m. - 3.00 p.m.,FDT,FDT 4209,Sensory Evaluation
 06.05.2026,1.00 p.m. - 3.00 p.m.,MTT,MTT 4201,Fluid Mechanics
-16.05.2026,9.00 a.m. - 11.00 a.m.,ALL,CML 4201,Entrepreneurship
+16.05.2026,1.00 p.m. - 3.00 p.m.,ALL,CML 4201,Entrepreneurship
 29.04.2026,2.00 p.m. - 4.00 p.m.,BPT,BPT 4206,Pharmaceutical Biotechnology
 29.04.2026,2.00 p.m. - 4.00 p.m.,FDT,FDT 4206,Supply Chain Analysis
 29.04.2026,2.00 p.m. - 4.00 p.m.,EET,EET 4208,Fiber Optic Techniques
 29.04.2026,2.00 p.m. - 4.00 p.m.,MTT,MTT 4206,Mineral Processing
-04.05.2026,1.00 p.m. onwards,EET,EET 4301,Electronic Circuit Design and Simulations (Prac)
+26.05.2026,1.00 p.m. onwards,EET,EET 4301,Electronic Circuit Design and Simulations (Prac)
 04.05.2026,2.00 p.m. - 5.00 p.m.,BPT,BPT 4302,Downstream Process Technology
 04.05.2026,2.00 p.m. - 5.00 p.m.,MTT,MTT 4305,Polymer Technology II
 
@@ -171,7 +171,7 @@ Date,Time,Dept.,Subject,Title
 12.05.2026,2.00 p.m. - 4.00 p.m.,FDT,FDT 4208,Cleaner Production
 12.05.2026,2.00 p.m. - 4.00 p.m.,EET,EET 4216,Energy and Environment
 12.05.2026,2.00 p.m. - 3.30 p.m.,MTT,MTT 4121,Research Methodology and Scientific Writing
-26.05.2026,9.00 a.m. onwards,EET,EET 4206,Automation Technology II - Practical exam
+21.05.2026,9.00 a.m. onwards,EET,EET 4206,Automation Technology II - Practical exam
 26.05.2026,9.00 a.m. - 10.00 a.m.,FDT,FDT 4107,Scientific Writing
 26.05.2026,9.00 a.m. - 11.00 a.m.,BPT,BPT 4204,Molecular Virology (Theory)
 26.05.2026,9.00 a.m. - 11.00 a.m.,MTT,MTT 4219,Applied Mechanics


### PR DESCRIPTION
Adjust multiple exam entries in lib/timetable.ts to correct dates and times. Notable fixes: ICT 2304 practical end time changed to 11:00 (01.06.2026); FDT 2201 moved from 14.05 to 15.05; ICT 3312 rescheduled to 05.05; ICT 3307 theory moved to 14.05 and its practical kept on 26.05; ICT 3208 moved to 11.05 afternoon; ICT 3218 moved to 30.04; EET 3210 rescheduled to 26.05 09:00-11:00; BPT 3302 extended to 14:00-17:00; CML 3101 shortened to 14:00-15:00; EET 4304 moved to 04.05; CML 4201 time changed to 13:00-15:00; EET 4301 practical moved to 26.05 13:00 onwards; EET 4206 practical moved to 21.05, plus several other minor timetable corrections and time adjustments across departments.